### PR TITLE
Try/except at import instead of for each function use

### DIFF
--- a/b2blaze/utilities.py
+++ b/b2blaze/utilities.py
@@ -10,23 +10,19 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 Additional code copyright George Sibble 2018
 """
 
-import urllib
 try:
-    import urllib.parse
+    from urllib import quote, unquote_plus
 except ImportError:
-    pass
+    from urllib.parse import quote, unquote_plus
+
 
 def b2_url_encode(s):
-    try:
-        return urllib.quote(s.encode('utf-8'))
-    except Exception:
-        return urllib.parse.quote(s.encode('utf-8'))
+    return quote(s.encode('utf-8'))
+
 
 def b2_url_decode(s):
-    try:
-        return urllib.unquote_plus(str(s)).decode('utf-8')
-    except Exception:
-        return urllib.parse.unquote_plus(str(s)).decode('utf-8')
+    return unquote_plus(str(s)).decode('utf-8')
+
 
 def decode_error(response):
     try:


### PR DESCRIPTION
If you were using Python 3, every time you call either of these functions you would be raising an exception by always first looking in the wrong place. This PR modifies the code to do a single check at import time only.

This try/except could also be removed by using `six.moves` but I wasn't clear on why `six` was only in `requirements.txt` but not in `setup.py`?

```python
from six.moves.urllib.parse import quote, unquote_plus
```