### PR TITLE
Add Multithreaded Large File Upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,14 +122,28 @@ bucket.files.all()
 
 NOTE: There may be tens of thousands of files (or more) in a bucket. This operation will get information and create objects for all of them. It may take quite some time and be computationally expensive to run.
 
-#### Create (upload) a File
+#### Upload a File
 
 ```python
 text_file = open('hello.txt').read()
 new_file = bucket.files.upload(contents=text_file, file_name='folder/hello.txt')
 ```
 
-NOTE: Reading the file is optional. You don't have to call .read() and instead can send the file directly to contents. This should save some memory.
+NOTE: Reading the file is optional. You don't have to call `.read()` and instead can send the file directly to contents. This should save some memory.
+
+#### Upload a Large File
+
+```python
+large_file = open('large_file.bin', 'rb')
+new_file = bucket.files.upload_large_file(contents=large_file, file_name='folder/large_file.bin',
+                                          part_size=100*1000*1000, num_threads=4)
+```
+
+NOTE: You cannot call `.read()` on the file because the function will do it for you, buffering `part_size` at a time across `num_threads`. Make sure that `part_size * num_threads` bytes of memory is available on your system.
+
+NOTE2: Per [Backblaze recommendation](https://www.backblaze.com/b2/docs/large_files.html), `part_size` defaults to `recommendedPartSize` from `b2_authorize_account` (typically 100MB). `num_threads` defaults to 4 threads.
+
+NOTE3: The minimum part size is 5MB and you must have must have at least 2 parts.
 
 #### Retrieve a File's Information (Necessary before Downloading)
 

--- a/README.md
+++ b/README.md
@@ -125,25 +125,20 @@ NOTE: There may be tens of thousands of files (or more) in a bucket. This operat
 #### Upload a File
 
 ```python
-text_file = open('hello.txt').read()
+text_file = open('hello.txt', 'rb')
 new_file = bucket.files.upload(contents=text_file, file_name='folder/hello.txt')
 ```
 
-NOTE: Reading the file is optional. You don't have to call `.read()` and instead can send the file directly to contents. This should save some memory.
+NOTE: You don't have to call `.read()` and instead can send the file directly to contents. This will allow the file buffer directly over HTTP to B2 and save a significant amount of memory. Also, `contents` must be binary or a binary stream.
 
 #### Upload a Large File
 
 ```python
 large_file = open('large_file.bin', 'rb')
-new_file = bucket.files.upload_large_file(contents=large_file, file_name='folder/large_file.bin',
-                                          part_size=100*1000*1000, num_threads=4)
+new_file = bucket.files.upload_large_file(contents=large_file, file_name='folder/large_file.bin', num_threads=4)
 ```
 
-NOTE: You cannot call `.read()` on the file because the function will do it for you, buffering `part_size` at a time across `num_threads`. Make sure that `part_size * num_threads` bytes of memory is available on your system.
-
-NOTE2: Per [Backblaze recommendation](https://www.backblaze.com/b2/docs/large_files.html), `part_size` defaults to `recommendedPartSize` from `b2_authorize_account` (typically 100MB). `num_threads` defaults to 4 threads.
-
-NOTE3: The minimum part size is 5MB and you must have must have at least 2 parts.
+NOTE: You cannot call `.read()` on the file because the function will seek and buffer the file over `num_threads` for you. Per [Backblaze recommendation](https://www.backblaze.com/b2/docs/large_files.html), `part_size` defaults to `recommendedPartSize` from `b2_authorize_account` (typically 100MB). `num_threads` defaults to 4 threads. The minimum part size is 5MB and you must have must have at least 2 parts.
 
 #### Retrieve a File's Information (Necessary before Downloading)
 

--- a/b2blaze/connector.py
+++ b/b2blaze/connector.py
@@ -7,7 +7,7 @@ from requests.auth import HTTPBasicAuth
 from b2blaze.b2_exceptions import B2AuthorizationError, B2RequestError, B2InvalidRequestType
 import sys
 from hashlib import sha1
-from b2blaze.utilities import b2_url_encode, read_in_chunks, decode_error
+from b2blaze.utilities import b2_url_encode, decode_error, get_content_length, StreamWithHashProgress
 
 class B2Connector(object):
     """
@@ -100,25 +100,8 @@ class B2Connector(object):
         else:
             raise B2AuthorizationError('Unknown Error')
 
-    def _sha(self, file_contents):
-        buf_size = 65536
-        if hasattr(file_contents, 'read'):  # If it has `read`, then it's a file-like object that we can stream
-            sha = sha1()
-            for chunk in read_in_chunks(file_contents, buf_size):
-                sha.update(chunk)
-            file_sha = sha.hexdigest()
-            file_contents.seek(0)
-        else:
-            if isinstance(file_contents, str) == True:
-                try:
-                    file_sha = sha1(file_contents.encode('utf-8')).hexdigest()
-                except UnicodeDecodeError:
-                    file_sha = sha1(file_contents).hexdigest()
-            else:
-                file_sha = sha1(file_contents).hexdigest()
-        return file_sha
-
-    def upload_file(self, file_contents, file_name, upload_url, auth_token, direct=False, mime_content_type=None):
+    def upload_file(self, file_contents, file_name, upload_url, auth_token,
+                    direct=False, mime_content_type=None, content_length=None, progress_listener=None):
         """
 
         :param file_contents:
@@ -126,20 +109,33 @@ class B2Connector(object):
         :param upload_url:
         :param auth_token:
         :param mime_content_type:
+        :param content_length
+        :param progress_listener
         :return:
         """
-        file_sha = self._sha(file_contents)
+        if hasattr(file_contents, 'read'):
+            if content_length is None:
+                content_length = get_content_length(file_contents)
+            file_sha = 'hex_digits_at_end'
+            data = StreamWithHashProgress(stream=file_contents, progress_listener=progress_listener)
+            content_length += data.hash_size()
+        else:
+            if content_length is None:
+                content_length = len(file_contents)
+            file_sha = sha1(file_contents).hexdigest()
+            data = file_contents
 
         headers = {
             'Content-Type': mime_content_type or 'b2/x-auto',
+            'Content-Length': str(content_length),
             'X-Bz-Content-Sha1': file_sha,
             'X-Bz-File-Name': b2_url_encode(file_name),
             'Authorization': auth_token
         }
 
-        return requests.post(upload_url, headers=headers, data=file_contents)
+        return requests.post(upload_url, headers=headers, data=data)
 
-    def upload_part(self, file_contents, content_length, part_number, upload_url, auth_token):
+    def upload_part(self, file_contents, content_length, part_number, upload_url, auth_token, progress_listener=None):
         """
 
         :param file_contents:
@@ -147,9 +143,12 @@ class B2Connector(object):
         :param part_number:
         :param upload_url:
         :param auth_token:
+        :param progress_listener:
         :return:
         """
-        file_sha = self._sha(file_contents)
+        file_sha = 'hex_digits_at_end'
+        data = StreamWithHashProgress(stream=file_contents, progress_listener=progress_listener)
+        content_length += data.hash_size()
 
         headers = {
             'Content-Length': str(content_length),
@@ -158,7 +157,7 @@ class B2Connector(object):
             'Authorization': auth_token
         }
 
-        return (requests.post(upload_url, headers=headers, data=file_contents), file_sha)
+        return requests.post(upload_url, headers=headers, data=data)
 
     def download_file(self, file_id):
         """

--- a/b2blaze/connector.py
+++ b/b2blaze/connector.py
@@ -28,6 +28,7 @@ class B2Connector(object):
         self.authorized_at = None
         self.api_url = None
         self.download_url = None
+        self.recommended_part_size = None
         self.api_session = None
         #TODO:  Part Size
         self._authorize()
@@ -62,6 +63,7 @@ class B2Connector(object):
             self.auth_token = result_json['authorizationToken']
             self.api_url = result_json['apiUrl'] + '/b2api/v1'
             self.download_url = result_json['downloadUrl'] + '/file/'
+            self.recommended_part_size = result_json['recommendedPartSize']
             self.api_session = requests.Session()
             self.api_session.headers.update({
                 'Authorization': self.auth_token
@@ -137,19 +139,17 @@ class B2Connector(object):
 
         return requests.post(upload_url, headers=headers, data=file_contents)
 
-    def upload_part(self, file_contents, content_length, part_number, sha_list, upload_url, auth_token):
+    def upload_part(self, file_contents, content_length, part_number, upload_url, auth_token):
         """
 
         :param file_contents:
         :param content_length:
         :param part_number:
-        :param sha_list:
         :param upload_url:
         :param auth_token:
         :return:
         """
         file_sha = self._sha(file_contents)
-        sha_list.append(file_sha)
 
         headers = {
             'Content-Length': str(content_length),
@@ -158,7 +158,7 @@ class B2Connector(object):
             'Authorization': auth_token
         }
 
-        return requests.post(upload_url, headers=headers, data=file_contents)
+        return (requests.post(upload_url, headers=headers, data=file_contents), file_sha)
 
     def download_file(self, file_id):
         """

--- a/b2blaze/connector.py
+++ b/b2blaze/connector.py
@@ -7,7 +7,7 @@ from requests.auth import HTTPBasicAuth
 from b2blaze.b2_exceptions import B2AuthorizationError, B2RequestError, B2InvalidRequestType
 import sys
 from hashlib import sha1
-from b2blaze.utilities import b2_url_encode, decode_error
+from b2blaze.utilities import b2_url_encode, read_in_chunks, decode_error
 
 class B2Connector(object):
     """
@@ -102,11 +102,8 @@ class B2Connector(object):
         buf_size = 65536
         if hasattr(file_contents, 'read'):  # If it has `read`, then it's a file-like object that we can stream
             sha = sha1()
-            buf = file_contents.read(buf_size)
-            file_size = len(buf)
-            while len(buf) > 0:
-                sha.update(buf)
-                buf = file_contents.read(buf_size)
+            for chunk in read_in_chunks(file_contents, buf_size):
+                sha.update(chunk)
             file_sha = sha.hexdigest()
             file_contents.seek(0)
         else:

--- a/b2blaze/models/file_list.py
+++ b/b2blaze/models/file_list.py
@@ -107,7 +107,6 @@ class B2FileList(object):
         #     return self._files_by_id.get(file_id, None)
         # pass
 
-
     def upload(self, contents, file_name, mime_content_type=None):
         """
 
@@ -122,10 +121,10 @@ class B2FileList(object):
         params = {
             'bucketId': self.bucket.bucket_id
         }
-        upload_url_request = self.connector.make_request(path=get_upload_url_path, method='post', params=params)
-        if upload_url_request.status_code == 200:
-            upload_url = upload_url_request.json().get('uploadUrl', None)
-            auth_token = upload_url_request.json().get('authorizationToken', None)
+        upload_url_response = self.connector.make_request(path=get_upload_url_path, method='post', params=params)
+        if upload_url_response.status_code == 200:
+            upload_url = upload_url_response.json().get('uploadUrl', None)
+            auth_token = upload_url_response.json().get('authorizationToken', None)
             upload_response = self.connector.upload_file(file_contents=contents, file_name=file_name,
                                                          upload_url=upload_url, auth_token=auth_token)
             if upload_response.status_code == 200:
@@ -134,4 +133,4 @@ class B2FileList(object):
             else:
                 raise B2RequestError(decode_error(upload_response))
         else:
-            raise B2RequestError(decode_error(upload_url_request))
+            raise B2RequestError(decode_error(upload_url_response))

--- a/b2blaze/utilities.py
+++ b/b2blaze/utilities.py
@@ -23,6 +23,11 @@ def b2_url_encode(s):
 def b2_url_decode(s):
     return unquote_plus(str(s)).decode('utf-8')
 
+def read_in_chunks(file, chunk_size):
+    chunk = file.read(chunk_size)
+    while chunk:
+        yield chunk
+        chunk = file.read(chunk_size)
 
 def decode_error(response):
     try:


### PR DESCRIPTION
## Changes

* Add multithreaded large file upload via `B2FileList.upload_large_file`
* Add `B2Connector.upload_part` for uploading parts of a large file
* Add `recommended_part_size` to `B2Connector._authorize`
* Update `README`

For multithreading, we use `multiprocessing.dummy` to import a `ThreadPool` and perform a `pool.map` of `b2_get_upload_part_url` and `b2_upload_part` across `get_part_ranges(content_length, part_size)`. `part_size` defaults to `recommended_part_size` and `num_threads` defaults to 4.

Fixes https://github.com/sibblegp/b2blaze/issues/7.