### PR TITLE
[Major bug] Fix self.authorized return if we need to self._authorize

### DIFF
--- a/b2blaze/connector.py
+++ b/b2blaze/connector.py
@@ -45,8 +45,7 @@ class B2Connector(object):
         else:
             if (datetime.datetime.utcnow() - self.authorized_at) > datetime.timedelta(hours=23):
                 self._authorize()
-            else:
-                return True
+            return True
 
 
     def _authorize(self):


### PR DESCRIPTION
If we need to re-authorize (after 23 hrs), `self._authorize` works fine and `self.auth_token` is refreshed but we end up not returning anything in `self.authorized`!

If nothing is returned, Python defaults to `None`. This will cause `make_request` to raise `B2AuthorizationError('Unknown Error')` whenever we need to re-authorize because `if self.authorized` evaluates to `False`.

I would say this is a pretty major bug because if you are instantiating B2 once on startup, after 23 hrs passes and we need to re-authorize for a new request, `make_request` will fail.