### PR TITLE
Python3 branch?

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     docker:
       # specify the version you desire here
       # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
-      - image: circleci/python:2.7.15
+      - image: circleci/python:3.6.6
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ cryptography==2.3
 curtsies==0.3.0
 enum34==1.1.6
 funcsigs==1.0.2
-futures==3.2.0
 greenlet==0.4.13
 idna==2.7
 ipaddress==1.0.22

--- a/tests.py
+++ b/tests.py
@@ -104,10 +104,7 @@ class TestB2(object):
         buckets = self.b2.buckets.all()
         expect(len(buckets)).should.be.greater_than(0)
         current_bucket = None
-        for bucket in buckets:
-            if bucket.bucket_name == self.bucket_name:
-                current_bucket = bucket
-        assert current_bucket != None
+        assert any(bucket for bucket in buckets if bucket.bucket_name == self.bucket_name) == True
         
 
     def test_get_files(self):

--- a/tests.py
+++ b/tests.py
@@ -43,7 +43,7 @@ class TestB2(object):
         :return: None
         """
         bucket = self.b2.buckets.get(bucket_name=self.bucket_name)
-        file = bucket.files.upload(contents='Hello World!', file_name='test/hello.txt')
+        file = bucket.files.upload(contents='Hello World!'.encode('utf-8'), file_name='test/hello.txt')
         file2 = bucket.files.get(file_id=file.file_id)
 
     def test_create_z_binary_file(self):
@@ -102,7 +102,13 @@ class TestB2(object):
         :return: None
         """
         buckets = self.b2.buckets.all()
-        expect(len(buckets)).should.be.greater_than(1)
+        expect(len(buckets)).should.be.greater_than(0)
+        current_bucket = None
+        for bucket in buckets:
+            if bucket.bucket_name == self.bucket_name:
+                current_bucket = bucket
+        assert current_bucket != None
+        
 
     def test_get_files(self):
         """


### PR DESCRIPTION
Hello,

I'm using b2blaze to upload backups of my websites on Ubuntu 16.04 LTS and Python 3.6. While uploading large files I get connection errors very often.

I've forked the repository on my account and started working on implementing the ability to continue uploading a large multi-part file after the initial upload has failed. I think that in a few weeks the code should be ready. For now I've changed the Python image in my repository to version 3.6 and made some changes in the code to make the tests run successfully.

Can someone please review the changes I've made and see maybe it will be better to create a Python3-only branch? I've also previously used Python only for my scripts so any kind of constructive criticism is welcome. 

Thank you very much.