### PR TITLE
Fixed deleting files with spaces in filename

### DIFF
--- a/b2blaze/models/b2_file.py
+++ b/b2blaze/models/b2_file.py
@@ -48,7 +48,7 @@ class B2File(object):
         path = '/b2_delete_file_version'
         params = {
             'fileId': self.file_id,
-            'fileName': b2_url_encode(self.file_name)
+            'fileName': self.file_name
         }
         response = self.connector.make_request(path=path, method='post', params=params)
         if response.status_code == 200:


### PR DESCRIPTION
url encoding filenames will cause a fileName not found error in b2_file.delete(). You need to keep the filename as is.
```
def delete(self):
    ...
    params = {
        'fileId': self.file_id,
        'fileName': b2_url_encode(self.file_name)
    }
```
should be 
```
def delete(self):
    ...
    params = {
        'fileId': self.file_id,
        'fileName': self.file_name
    }
```