### PR TITLE
Improve behaviour with restricted application keys

### DIFF
--- a/b2blaze/b2lib.py
+++ b/b2blaze/b2lib.py
@@ -34,5 +34,5 @@ class B2(object):
 
         :return:
         """
-        return B2Buckets(connector=self.connector)
+        return B2Buckets(connector=self.connector, single_bucket=self.connector.bucket_id)
 

--- a/b2blaze/connector.py
+++ b/b2blaze/connector.py
@@ -29,6 +29,7 @@ class B2Connector(object):
         self.download_url = None
         self.recommended_part_size = None
         self.api_session = None
+        self.bucket_id = None
         #TODO:  Part Size
         self._authorize()
 
@@ -63,6 +64,8 @@ class B2Connector(object):
             self.api_url = result_json['apiUrl'] + API_VERSION
             self.download_url = result_json['downloadUrl'] + API_VERSION + API.download_file_by_id
             self.recommended_part_size = result_json['recommendedPartSize']
+            if result_json.get('allowed'):
+                self.bucket_id = result_json['allowed'].get('bucketId', None)
             self.api_session = requests.Session()
             self.api_session.headers.update({
                 'Authorization': self.auth_token

--- a/b2blaze/models/bucket_list.py
+++ b/b2blaze/models/bucket_list.py
@@ -14,12 +14,14 @@ class B2Buckets(object):
     public = 'allPublic'
     private = 'allPrivate'
 
-    def __init__(self, connector):
+    def __init__(self, connector, single_bucket=None):
         """
 
         :param connector:
+        :param str single_bucket: If any, the ID of the single bucket that we can list.
         """
         self.connector = connector
+        self._single_bucket = single_bucket
         self._buckets_by_name = {}
         self._buckets_by_id = {}
 
@@ -37,7 +39,10 @@ class B2Buckets(object):
         :return:
         """
         path = API.list_all_buckets
-        response = self.connector.make_request(path=path, method='post', account_id_required=True)
+        params = {}
+        if self._single_bucket:
+            params['bucketId'] = self._single_bucket
+        response = self.connector.make_request(path=path, method='post', account_id_required=True, params=params)
         if response.status_code == 200:
             response_json = response.json()
             buckets = []


### PR DESCRIPTION
It is now possible to create [application keys with restrictions](https://www.backblaze.com/b2/docs/application_keys.html). These keys only have one access to one bucket, and to a subset of possible API calls.

Most importantly, these restricted keys cannot freely call `b2_list_buckets`, which renders them unusable with b2blaze. This PR makes a minimal change to make these keys work: when using such a restricted key, only try listing the one permitted bucket.

This is an incomplete solution: a key could theoretically not have the ability to call `b2_list_buckets` even for its single permitted bucket, and b2blaze has little reason to require that they can. However, it solves the most common case where the keys are created via the web UI, which always grants access to `b2_list_buckets`.

I've tested this using the subset of the integration tests that don't involve creating/destroying buckets, but by the nature of the problem and the current testing setup, I can't really include these tests in the repo usefully.