### PR TITLE
Remove B2FileList's unused file cache

### DIFF
--- a/b2blaze/models/b2_file.py
+++ b/b2blaze/models/b2_file.py
@@ -81,9 +81,6 @@ class B2File(object):
         response = self.connector.make_request(path=path, method='post', params=params)
         if response.status_code == 200:
             self.deleted = True
-            # Delete from parent list if exists
-            self.parent_list._files_by_name.pop(self.file_name)
-            self.parent_list._files_by_id.pop(self.file_id)
         else:
             raise B2Exception.parse(response)
 


### PR DESCRIPTION
`B2FileList` maintains a cache of files in a bucket, and updates it on some (but not all) mutation operations. However, the cache is never read.

This PR removes the cache, primarily because it isn't used. As motivation, in its current implementation, maintaining the cache is extraordinarily expensive. In particular, every time a file is uploaded, the _entire bucket_ is listed again. This is expensive in both requests and bandwidth, especially when uploading a batch of many files (when you will make O(n^2) requests to upload n files). Many (most?) B2 use cases don't need a complete bucket listing at all.

The behaviour of the cache could potentially be improved instead of removing it, but given it is entirely unused, doing so didn't seem worth the effort here.